### PR TITLE
Additional fields for DB exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,30 @@ Exceptions
 
 All database errors, including broken SQL queries, are thrown as exceptions.
 
+Exceptions for a query result may have additional fields as reported by PostgreSQL with the mapping below (perl exception field ➡ PostgreSQL field name):
+
+* message ➡ PG_DIAG_MESSAGE_PRIMARY
+* message-detail ➡ PG_DIAG_MESSAGE_DETAIL
+* message-hint ➡ PG_DIAG_MESSAGE_HINT
+* context ➡ PG_DIAG_CONTEXT
+* type ➡ PG_DIAG_SEVERITY_NONLOCALIZED
+* type-localized ➡ PG_DIAG_SEVERITY
+* state ➡ PG_DIAG_SQLSTATE
+* statement-position ➡ PG_DIAG_STATEMENT_POSITION
+* internal-position ➡ PG_DIAG_INTERNAL_POSITION
+* internal-query ➡ PG_DIAG_INTERNAL_QUERY
+* schema ➡ PG_DIAG_SCHEMA_NAME
+* table ➡ PG_DIAG_TABLE_NAME
+* column ➡ PG_DIAG_COLUMN_NAME
+* datatype ➡ PG_DIAG_DATATYPE_NAME
+* constraint ➡ PG_DIAG_CONSTRAINT_NAME
+* source-file ➡ PG_DIAG_SOURCE_FILE
+* source-line ➡ PG_DIAG_SOURCE_LINE
+* source-function ➡ PG_DIAG_SOURCE_FUNCTION
+
+Please see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/static/libpq-exec.html#LIBPQ-PQRESULTERRORFIELD)
+for a detailed description of what each field contains.
+
 NOTE
 ----
 

--- a/lib/DB/Pg/Database.pm6
+++ b/lib/DB/Pg/Database.pm6
@@ -120,15 +120,41 @@ class DB::Pg::Database
                 die DB::Pg::Error::EmptyQuery.new(message => 'Empty Query')
             }
             when PGRES_FATAL_ERROR {
-                $result.clear;
                 die DB::Pg::Error::FatalError.new(
-                    message => $!conn.error-message)
+                    message => $result.error-field(PG_DIAG_MESSAGE_PRIMARY),
+                    message-detail => $result.error-field(PG_DIAG_MESSAGE_DETAIL),
+                    message-hint => $result.error-field(PG_DIAG_MESSAGE_HINT),
+                    context => $result.error-field(PG_DIAG_CONTEXT),
+                    type => $result.error-field(PG_DIAG_SEVERITY_NONLOCALIZED),
+                    type-localized => $result.error-field(PG_DIAG_SEVERITY),
+                    state => $result.error-field(PG_DIAG_SQLSTATE),
+
+                    statement-position => $result.error-field(PG_DIAG_STATEMENT_POSITION),
+                    internal-position => $result.error-field(PG_DIAG_INTERNAL_POSITION),
+                    internal-query => $result.error-field(PG_DIAG_INTERNAL_QUERY),
+
+                    schema => $result.error-field(PG_DIAG_SCHEMA_NAME),
+                    table => $result.error-field(PG_DIAG_TABLE_NAME),
+                    column => $result.error-field(PG_DIAG_COLUMN_NAME),
+                    datatype => $result.error-field(PG_DIAG_DATATYPE_NAME),
+                    constraint => $result.error-field(PG_DIAG_CONSTRAINT_NAME),
+
+                    source-file => $result.error-field(PG_DIAG_SOURCE_FILE),
+                    source-line => $result.error-field(PG_DIAG_SOURCE_LINE),
+                    source-function => $result.error-field(PG_DIAG_SOURCE_FUNCTION),
+                );
+                $result.clear;
             }
             when PGRES_COMMAND_OK|PGRES_TUPLES_OK|PGRES_COPY_OUT|PGRES_COPY_IN {
                 $result
             }
             default {...}
         }
+    }
+
+    method error-field(PGresult:D $result, ResultErrorField:D $field-name)
+    {
+		return $result.error-field($result, $field-name);
     }
 
     method prepare(Str:D $query --> DB::Pg::Statement)

--- a/lib/DB/Pg/Native.pm6
+++ b/lib/DB/Pg/Native.pm6
@@ -20,9 +20,50 @@ enum ExecStatusType <
     PGRES_SINGLE_TUPLE
 >;
 
+enum ResultErrorField (
+    PG_DIAG_SEVERITY              => ord('S'),
+    PG_DIAG_SEVERITY_NONLOCALIZED => ord('V'),
+    PG_DIAG_SQLSTATE              => ord('C'),
+    PG_DIAG_MESSAGE_PRIMARY       => ord('M'),
+    PG_DIAG_MESSAGE_DETAIL        => ord('D'),
+    PG_DIAG_MESSAGE_HINT          => ord('H'),
+    PG_DIAG_STATEMENT_POSITION    => ord('P'),
+    PG_DIAG_INTERNAL_POSITION     => ord('p'),
+    PG_DIAG_INTERNAL_QUERY        => ord('q'),
+    PG_DIAG_CONTEXT               => ord('W'),
+    PG_DIAG_SCHEMA_NAME           => ord('s'),
+    PG_DIAG_TABLE_NAME            => ord('t'),
+    PG_DIAG_COLUMN_NAME           => ord('c'),
+    PG_DIAG_DATATYPE_NAME         => ord('d'),
+    PG_DIAG_CONSTRAINT_NAME       => ord('n'),
+    PG_DIAG_SOURCE_FILE           => ord('F'),
+    PG_DIAG_SOURCE_LINE           => ord('L'),
+    PG_DIAG_SOURCE_FUNCTION       => ord('R'),
+);
+
 class DB::Pg::Error is Exception
 {
-    has $.message;
+    has Str $.message;
+    has Str $.message-detail;
+    has Str $.message-hint;
+	has Str $.context;
+	has Str $.type;
+	has Str $.type-localized;
+	has Str $.state;
+
+	has Str $.statement-position;
+	has Str $.internal-position;
+	has Str $.internal-query;
+
+	has Str $.schema;
+	has Str $.table;
+	has Str $.column;
+	has Str $.datatype;
+	has Str $.constraint;
+
+	has Str $.source-file;
+	has Str $.source-line;
+	has Str $.source-function;
 }
 
 class DB::Pg::Error::EmptyQuery    is DB::Pg::Error {}
@@ -44,6 +85,9 @@ class PGresult is repr('CPointer')
 
     method error-message(--> Str) is native(LIBPQ)
         is symbol('PQresultErrorMessage') {}
+
+    method error-field(int32 $field_number --> Str) is native(LIBPQ)
+        is symbol('PQresultErrorField') { }
 
     method clear() is native(LIBPQ)
         is symbol('PQclear') {}
@@ -220,7 +264,7 @@ class DB::Pg::CopyOutIterator does Iterator
             }
             when -2     # Error
             {
-                die DB::Pg::Error(message => $!db.conn.error-message);
+                die DB::Pg::Error(message => $!db.conn.error-message, state => 'S8006');
             }
         }
     }

--- a/t/15-exception.t
+++ b/t/15-exception.t
@@ -1,0 +1,62 @@
+use Test;
+use Test::When <extended>;
+
+use DB::Pg;
+
+plan 3;
+
+my $pg = DB::Pg . new;
+
+throws-like {
+    $pg.query(q{DO LANGUAGE plpgsql $$BEGIN RAISE EXCEPTION 'Fake serialization failure' USING ERRCODE = '40001'; END;$$;});
+}, DB::Pg::Error::FatalError, 'Raise Exception',
+    message => 'Fake serialization failure',
+    context => 'PL/pgSQL function inline_code_block line 1 at RAISE',
+    state   => '40001',
+    type    => 'ERROR',
+    type-localized => /^ .+ $/,
+    source-file => 'pl_exec.c',
+    source-line => / \d+ /,
+    source-function => 'exec_stmt_raise';
+
+throws-like {
+    $pg.query(q{SELECT nocolumn FROM pg_class;});
+}, DB::Pg::Error::FatalError, 'Incorrect column',
+    message => q{column "nocolumn" does not exist},
+    state   => '42703',
+    type    => 'ERROR',
+    type-localized => /^ .+ $/,
+    source-file   => 'parse_relation.c',
+    source-line   => / \d+ /,
+    source-function => 'errorMissingColumn';
+
+
+throws-like {
+    my $query = q:to/_QUERY_/;
+      DO LANGUAGE plpgsql $$
+        BEGIN RAISE EXCEPTION 'Field Test' USING
+                ERRCODE = 'ERR99', DETAIL = 'Detail', HINT = 'Hint',
+                COLUMN = 'Column', CONSTRAINT = 'Constraint', DATATYPE = 'Datatype',
+                TABLE = 'Table', SCHEMA = 'Schema';
+        END;$$;
+      _QUERY_
+
+    $pg.query($query);
+}, DB::Pg::Error::FatalError, 'Raise Exception',
+    message => 'Field Test',
+    message-detail => 'Detail',
+    message-hint => 'Hint',
+    context => 'PL/pgSQL function inline_code_block line 2 at RAISE',
+    state   => 'ERR99',
+    type    => 'ERROR',
+    schema => 'Schema',
+    table => 'Table',
+    column => 'Column',
+    datatype => 'Datatype',
+    constraint => 'Constraint',
+    type-localized => /^ .+ $/,
+    source-file => 'pl_exec.c',
+    source-line => / \d+ /,
+    source-function => 'exec_stmt_raise';
+
+done-testing;


### PR DESCRIPTION
These are required to do any type of retry loop for temporary failures such as serialization issues.

Note that "message" is now the shortened version without the DETAIL, CONTEXT, and TYPE fields attached. If people are doing regex matching to the error message, this change may cause issues but I think they'll be happy the process is significantly easier (exact match against state and other fields instead of regex against what may be a translation).

If you revert that portion, please add a "message-short" or something for just the basic error message string.