### PR TITLE
Parse empty arrays correctly

### DIFF
--- a/lib/DB/Pg/ArrayParser.pm6
+++ b/lib/DB/Pg/ArrayParser.pm6
@@ -2,7 +2,7 @@ grammar DB::Pg::ArrayParser
 {
     rule TOP         { ^ <array> $ }
 
-    rule array       { '{' ~ '}' <element>+ % ',' }
+    rule array       { '{' ~ '}' <element>* % ',' }
 
     rule element     { <array> | <string> | <quoted> | <null> }
 

--- a/t/11-array-parser.t
+++ b/t/11-array-parser.t
@@ -4,7 +4,7 @@ use Test::When <extended>;
 use DB::Pg::Converter;
 use DB::Pg::ArrayParser;
 
-plan 11;
+plan 12;
 
 my $converter = DB::Pg::Converter.new;
 
@@ -38,5 +38,7 @@ is-deeply parseit(Str, Q'{ "this\\that" }'), ['this\that'], 'embedded backslash'
 is-deeply parseit(Int, '{ NULL, 7, NULL }'), [Int, 7, Int], 'Int nulls';
 
 is-deeply parseit(Str, '{ NULL, 7, NULL }'), [Str, '7', Str], 'Str nulls';
+
+is-deeply parseit(Str, '{ }'), [], 'empty array';
 
 done-testing;


### PR DESCRIPTION
Noticed this at $job, we have a few cases of empty arrays and those threw an exception.