### PR TITLE
Add Results.col-array

### DIFF
--- a/lib/DB/Pg/Results.rakumod
+++ b/lib/DB/Pg/Results.rakumod
@@ -85,6 +85,12 @@ class DB::Pg::Results
         Seq.new: DB::Pg::ArrayIterator.new(res => self, :$!finish, :hash,
                                            rows => self.rows)
     }
+
+    method col-array(Int $col = 0)
+    {
+        LEAVE $.finish if $!finish;
+        (^$.rows).map({ $.row($_)[$col] }).Array
+    }
 }
 
 =begin pod
@@ -112,6 +118,8 @@ DB::Pg::Results -- Results from a PostgreSQL query
  say $results.arrays;   # A sequence of arrays with all rows
 
  say $results.hashes;   # A sequence of hashes with all rows
+
+ say $results.col-array;    # A single array of one column.
 
  $results.finish        # Only needed if results aren't consumed.
 
@@ -162,5 +170,9 @@ Returns a sequence of all rows as arrays.
 =head2 B<hashes>()
 
 Returns a sequence of all rows as hashes.
+
+=head2 B<col-array>(Int $col = 0)
+
+Retrieves a specific column from the results as an array.
 
 =end pod

--- a/t/04-array.t
+++ b/t/04-array.t
@@ -3,7 +3,7 @@ use Test::When <extended>;
 
 use DB::Pg;
 
-plan 4;
+plan 6;
 
 my $pg = DB::Pg.new;
 
@@ -16,5 +16,11 @@ is-deeply $pg.query('select generate_series(1,5) as x').hashes,
 is-deeply $pg.query('select generate_series(1,0)').arrays, (), 'No arrays';
 
 is-deeply $pg.query('select generate_series(1,0)').hashes, (), 'No hashes';
+
+is-deeply $pg.query('select generate_series(1,5)').col-array,
+    [1..5], 'col-array';
+
+is-deeply $pg.query('select 123, generate_series(1,5)').col-array(1),
+    [1..5], 'col-array(1)';
 
 done-testing;


### PR DESCRIPTION
Inspired by DBI's [selectcol_arrayref](https://metacpan.org/pod/DBI#selectcol_arrayref) method, allows you to pull just one column across many rows.

This would be useful in Raku Land at least where we do the following to produce an autocomplete route:
```raku
db.query( q:to/SQL/, $q ).arrays.flat.Array;
```
This would let us simplify it to:
```raku
db.query( q:to/SQL/, $q ).col-array;
```